### PR TITLE
support "analyzed" and "non-analyzed" when indexing metadata

### DIFF
--- a/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
@@ -152,7 +152,11 @@ object IndexDocuments extends App with LazyLogging {
   def indexKeyValueField(parent: Document, key: String, value: JValue): Unit ={
     value match {
       case JString(s) => {
-        parent.add(new TextField(key, s, Store.YES))
+        if (key.endsWith("_")) {
+          parent.add(new StringField(key.dropRight(1), s, Store.YES))
+        } else {
+          parent.add(new TextField(key, s, Store.YES))
+        }
       }
       case JLong(l) => {
         parent.add(new LongPoint(key, l))

--- a/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
@@ -10,6 +10,7 @@ import ai.lum.odinson.extra.IndexDocuments.mkParentDoc
 import ai.lum.odinson.extra.IndexDocuments.deserializeDocs
 import ai.lum.odinson.utils.ConfigFactory
 import com.typesafe.config.Config
+import org.apache.lucene.index.{IndexOptions, IndexableFieldType}
 import org.apache.lucene.store.FSDirectory
 import org.json4s.JsonAST._
 class IndexDocumentsTest extends FlatSpec with Matchers {
@@ -22,14 +23,21 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
 
   "mkParentDoc" should "return a document with simple metadata fields" in  {
     val parentDoc = mkParentDoc("001", JObject(List(
-      ("author", JString("John")),
+      ("author_", JString("John")),
+      ("title", JString("Lucene tips and tricks")),
       ("yearlong", JLong(1981)),
       ("yearint", JInt(1981)),
       ("costdouble", JDouble(30.4)),
       ("costdecimal", JDecimal(30.4)),
       ("free", JBool(false))
     )))
+
+    // We expect the author field to be added without the trailiing underscore (indicating a string value field)
     parentDoc.getField("author").stringValue shouldBe "John"
+    print(parentDoc.getField("author").fieldType.indexOptions)
+    parentDoc.getField("author").fieldType.tokenized shouldBe false
+    parentDoc.getField("title").stringValue shouldBe "Lucene tips and tricks"
+    parentDoc.getField("title").fieldType.tokenized shouldBe true
     parentDoc.getField("yearlong").numericValue shouldBe 1981l
     parentDoc.getField("yearint").numericValue shouldBe 1981
     parentDoc.getField("costdouble").numericValue shouldBe 30.4

--- a/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
@@ -34,7 +34,6 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
 
     // We expect the author field to be added without the trailiing underscore (indicating a string value field)
     parentDoc.getField("author").stringValue shouldBe "John"
-    print(parentDoc.getField("author").fieldType.indexOptions)
     parentDoc.getField("author").fieldType.tokenized shouldBe false
     parentDoc.getField("title").stringValue shouldBe "Lucene tips and tricks"
     parentDoc.getField("title").fieldType.tokenized shouldBe true


### PR DESCRIPTION
The PR guarantees that texutual metadata fields will be analyzed by default (i.e. the user can query based on one of the tokens in the value) and fields which end with "_" will be indexed but not analyzed (i.e. the user has to query by the whole field value).

Note: we index the non-analyzed fields without the trailing underscore.