### PR TITLE
Sentence level metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ FROM openjdk:8u212-jdk-stretch
 WORKDIR /local
 RUN mkdir /local/data
 
-# by default we build an image with tacred. To build with KBP pass --build-arg user=kbp-odinson-index-ordered-24092019
-# to docker build.
 COPY --from=builder /local/backend/target/universal/stage/ /local
 COPY --from=builder /local/scripts /local/scripts
 

--- a/backend/app/controllers/OdinsonController.scala
+++ b/backend/app/controllers/OdinsonController.scala
@@ -332,7 +332,8 @@ class OdinsonController @Inject()(system: ActorSystem, cc: ControllerComponents)
       "documentId" -> getDocId(odinsonScoreDoc.doc),
       "sentenceIndex" -> getSentenceIndex(odinsonScoreDoc.doc),
       "sentence" -> mkAbridgedSentence(odinsonScoreDoc.doc),
-      "matches" -> Json.arr(odinsonScoreDoc.matches.map(mkJson): _*)
+      "matches" -> Json.arr(odinsonScoreDoc.matches.map(mkJson): _*),
+      "md-json" -> mkSentenceMetadata(odinsonScoreDoc.doc)
     )
   }
 
@@ -347,4 +348,13 @@ class OdinsonController @Inject()(system: ActorSystem, cc: ControllerComponents)
     unabridgedJson.as[JsObject] - "startOffsets" - "endOffsets" - "raw"
   }
 
+  def mkSentenceMetadata(odinsonDocId: Int): JsValue = {
+    val sent = extractorEngine.indexSearcher.doc(odinsonDocId)
+    var metadataJsonStr =  "{}"
+    if (sent.getValues("md-json").nonEmpty) {
+      metadataJsonStr = sent.getValues("md-json").head
+    }
+    val metadataJson = Json.parse(metadataJsonStr)
+    metadataJson.as[JsObject]
+  }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -55,6 +55,11 @@ odinson {
     # so that they match
     normalizeQueriesToDefaultField = true
 
+    // Metadata fields are strings by default. Field names that appear in the list below with the value Integer will be treated as numeric by the query parser.
+    metadataTypeOverride {
+      year = "Integer"
+    }
+
   }
 
   index {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -42,6 +42,9 @@ odinson {
     # the token field to be used when none is specified
     defaultTokenField = ${odinson.index.normalizedTokenField}
 
+    # the metadata field to use when none is specified
+    defaultParentField = "title"
+
     sentenceLengthField = ${odinson.index.sentenceLengthField}
 
     dependenciesField = ${odinson.index.dependenciesField}

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -180,7 +180,7 @@ class ExtractorEngine(
 
       val parentQuery = (extractionQuery.odinsonQuery,
         extractionQuery.documentLuceneQuery) match {
-        case (None, Some(dq)) => Some(compiler.parentQueryParser.parse(dq, "docId"))
+        case (None, Some(dq)) => Some(compiler.compileParentQuery(dq))
         case _ => None
       }
 

--- a/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
+++ b/core/src/main/scala/ai/lum/odinson/ExtractorEngine.scala
@@ -180,7 +180,7 @@ class ExtractorEngine(
 
       val parentQuery = (extractionQuery.odinsonQuery,
         extractionQuery.documentLuceneQuery) match {
-        case (None, Some(dq)) => Some(compiler.queryParser.parse(dq))
+        case (None, Some(dq)) => Some(compiler.parentQueryParser.parse(dq, "docId"))
         case _ => None
       }
 

--- a/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
@@ -1,12 +1,15 @@
 package ai.lum.odinson.compiler
 
 import java.io.File
+import java.text.NumberFormat
+import java.util.Locale
 
 import org.apache.lucene.index._
 import org.apache.lucene.search._
 import org.apache.lucene.search.join._
 import org.apache.lucene.search.spans._
-import org.apache.lucene.queryparser.classic.{ QueryParser => LuceneQueryParser }
+import org.apache.lucene.queryparser.classic.{QueryParser => LuceneQueryParser}
+import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer
 import com.typesafe.config.Config
 import ai.lum.common.ConfigUtils._
@@ -15,7 +18,9 @@ import ai.lum.odinson.lucene.search.spans._
 import ai.lum.odinson.digraph._
 import ai.lum.odinson.state.State
 import ai.lum.odinson.utils.ConfigFactory
-
+import org.apache.lucene.document.FieldType
+import scala.collection.JavaConverters._
+import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig
 class QueryCompiler(
     val allTokenFields: Seq[String],
     val defaultTokenField: String,
@@ -31,6 +36,12 @@ class QueryCompiler(
 
   /** query parser for parent doc queries */
   val queryParser = new LuceneQueryParser("docId", new WhitespaceAnalyzer)
+
+  val parentQueryParser = new StandardQueryParser(new WhitespaceAnalyzer)
+
+
+  val numericConfig = new PointsConfig(NumberFormat.getNumberInstance(Locale.ENGLISH), classOf[java.lang.Integer])
+  parentQueryParser.setPointsConfigMap(Map("year" -> numericConfig).asJava)
 
   private var state: Option[State] = None
 
@@ -61,7 +72,7 @@ class QueryCompiler(
 
   def mkQuery(pattern: String, parentPattern: String): OdinsonQuery = {
     val query = compile(pattern)
-    val parentQuery = queryParser.parse(parentPattern)
+    val parentQuery = parentQueryParser.parse(parentPattern, "docId")
     mkQuery(query, parentQuery)
   }
 
@@ -71,7 +82,7 @@ class QueryCompiler(
   }
 
   def mkQuery(query: OdinsonQuery, parentPattern: String): OdinsonQuery = {
-    val parentQuery = queryParser.parse(parentPattern)
+    val parentQuery = parentQueryParser.parse(parentPattern, "docId")
     mkQuery(query, parentQuery)
   }
 

--- a/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
+++ b/core/src/main/scala/ai/lum/odinson/compiler/QueryCompiler.scala
@@ -39,7 +39,7 @@ class QueryCompiler(
 
   val parentQueryParser = new StandardQueryParser(new WhitespaceAnalyzer)
 
-
+  //todo: this is a nasty hack: it hard codes the parentQueryParser to treat year as Integer. This should be minimally read from config.
   val numericConfig = new PointsConfig(NumberFormat.getNumberInstance(Locale.ENGLISH), classOf[java.lang.Integer])
   parentQueryParser.setPointsConfigMap(Map("year" -> numericConfig).asJava)
 

--- a/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
@@ -152,7 +152,11 @@ object IndexDocuments extends App with LazyLogging {
   def indexKeyValueField(parent: Document, key: String, value: JValue): Unit ={
     value match {
       case JString(s) => {
-        parent.add(new TextField(key, s, Store.YES))
+        if (key.endsWith("_")) {
+          parent.add(new StringField(key.dropRight(1), s, Store.YES))
+        } else {
+          parent.add(new TextField(key, s, Store.YES))
+        }
       }
       case JLong(l) => {
         parent.add(new LongPoint(key, l))

--- a/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
+++ b/extra/src/main/scala/ai/lum/odinson/extra/IndexDocuments.scala
@@ -152,26 +152,22 @@ object IndexDocuments extends App with LazyLogging {
   def indexKeyValueField(doc: Document, key: String, value: JValue): Unit ={
     value match {
       case JString(s) => {
-        doc.add(new TextField(key, s, Store.YES))
+        doc.add(new TextField(key, s, Store.NO))
       }
       case JLong(l) => {
         doc.add(new LongPoint(key, l))
-        doc.add(new StoredField(key, l))
       }
       case JInt(i) => { // i is BigInteger, we truncate to int.
         doc.add(new IntPoint(key, i.toInt))
-        doc.add(new StoredField(key, i.toInt))
       }
       case JDouble(d) => {
         doc.add(new DoublePoint(key, d))
-        doc.add(new StoredField(key, d))
       }
       case JDecimal(f) => { // d is BigDecimal, we truncate to float.
         doc.add(new FloatPoint(key, f.toFloat))
-        doc.add(new StoredField(key, f.toFloat))
       }
       case JBool(b) => {
-        doc.add(new TextField(key, b.toString, Store.YES))
+        doc.add(new TextField(key, b.toString, Store.NO))
       }
       case _ => {
         logger.warn("Field skipped (type not supported): " + value.toString)

--- a/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
@@ -10,6 +10,7 @@ import ai.lum.odinson.extra.IndexDocuments.mkParentDoc
 import ai.lum.odinson.extra.IndexDocuments.deserializeDocs
 import ai.lum.odinson.utils.ConfigFactory
 import com.typesafe.config.Config
+import org.apache.lucene.index.{IndexOptions, IndexableFieldType}
 import org.apache.lucene.store.FSDirectory
 import org.json4s.JsonAST._
 class IndexDocumentsTest extends FlatSpec with Matchers {
@@ -22,14 +23,21 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
 
   "mkParentDoc" should "return a document with simple metadata fields" in  {
     val parentDoc = mkParentDoc("001", JObject(List(
-      ("author", JString("John")),
+      ("author_", JString("John")),
+      ("title", JString("Lucene tips and tricks")),
       ("yearlong", JLong(1981)),
       ("yearint", JInt(1981)),
       ("costdouble", JDouble(30.4)),
       ("costdecimal", JDecimal(30.4)),
       ("free", JBool(false))
     )))
+
+    // We expect the author field to be added without the trailiing underscore (indicating a string value field)
     parentDoc.getField("author").stringValue shouldBe "John"
+    print(parentDoc.getField("author").fieldType.indexOptions)
+    parentDoc.getField("author").fieldType.tokenized shouldBe false
+    parentDoc.getField("title").stringValue shouldBe "Lucene tips and tricks"
+    parentDoc.getField("title").fieldType.tokenized shouldBe true
     parentDoc.getField("yearlong").numericValue shouldBe 1981l
     parentDoc.getField("yearint").numericValue shouldBe 1981
     parentDoc.getField("costdouble").numericValue shouldBe 30.4

--- a/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
@@ -23,7 +23,7 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
 
   "mkParentDoc" should "return a document with simple metadata fields" in  {
     val parentDoc = mkParentDoc("001", JObject(List(
-      ("author_", JString("John")),
+      ("author", JString("John")),
       ("title", JString("Lucene tips and tricks")),
       ("yearlong", JLong(1981)),
       ("yearint", JInt(1981)),
@@ -34,7 +34,6 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
 
     // We expect the author field to be added without the trailiing underscore (indicating a string value field)
     parentDoc.getField("author").stringValue shouldBe "John"
-    parentDoc.getField("author").fieldType.tokenized shouldBe false
     parentDoc.getField("title").stringValue shouldBe "Lucene tips and tricks"
     parentDoc.getField("title").fieldType.tokenized shouldBe true
     parentDoc.getField("yearlong").numericValue shouldBe 1981l

--- a/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
@@ -34,7 +34,6 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
 
     // We expect the author field to be added without the trailiing underscore (indicating a string value field)
     parentDoc.getField("author").stringValue shouldBe "John"
-    print(parentDoc.getField("author").fieldType.indexOptions)
     parentDoc.getField("author").fieldType.tokenized shouldBe false
     parentDoc.getField("title").stringValue shouldBe "Lucene tips and tricks"
     parentDoc.getField("title").fieldType.tokenized shouldBe true

--- a/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
@@ -20,7 +20,7 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
   "mkParentDoc" should "return a document with simple metadata fields" in  {
     val parentDoc = mkParentDoc("001", JObject(List(
       ("author", JString("John")),
-      ("title", JString("Lucene tips and tricks")),
+      ("title_", JString("Lucene tips and tricks")),
       ("yearlong", JLong(1981)),
       ("yearint", JInt(1981)),
       ("costdouble", JDouble(30.4)),
@@ -63,7 +63,7 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
       )))
 
     // Make sure that we index only metadata fields that end with "_"
-    sentenceDoc.getField("md-json").stringValue shouldBe "{\"title_\":\"Lucene tips and tricks\"}"
+    sentenceDoc.getField("md-json").stringValue shouldBe "{\"title\":\"Lucene tips and tricks\"}"
   }
   "addSentenceMetadata" should "return a document with no metadata field" in {
 

--- a/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
+++ b/extra/src/test/scala/ai/lum/odinson/extra/IndexDocumentsTest.scala
@@ -1,17 +1,13 @@
 package ai.lum.odinson.extra
 
 import java.io.File
-import java.nio.file.Paths
 
-import ai.lum.odinson.extra.IndexDocuments
-import ai.lum.odinson.{ExtractionQueryParams, ExtractorEngine}
 import org.scalatest.{FlatSpec, Matchers}
 import ai.lum.odinson.extra.IndexDocuments.mkParentDoc
+import ai.lum.odinson.extra.IndexDocuments.addSentenceMetadata
 import ai.lum.odinson.extra.IndexDocuments.deserializeDocs
-import ai.lum.odinson.utils.ConfigFactory
-import com.typesafe.config.Config
-import org.apache.lucene.index.{IndexOptions, IndexableFieldType}
-import org.apache.lucene.store.FSDirectory
+import org.apache.lucene.document.Document
+import org.json4s.JNothing
 import org.json4s.JsonAST._
 class IndexDocumentsTest extends FlatSpec with Matchers {
 
@@ -50,6 +46,30 @@ class IndexDocumentsTest extends FlatSpec with Matchers {
     parentDoc.getFields("author").size shouldBe 2
     parentDoc.getFields("author")(0).stringValue shouldBe "John"
     parentDoc.getFields("author")(1).stringValue shouldBe "Jeff"
+  }
+
+
+  "addSentenceMetadata" should "return a document with a metadata field which includes only fields with underscore" in {
+    val sentenceDoc = new Document
+    addSentenceMetadata(sentenceDoc,
+      JObject(List(
+        ("author", JString("John")),
+        ("title_", JString("Lucene tips and tricks")),
+        ("yearlong", JLong(1981)),
+        ("yearint", JInt(1981)),
+        ("costdouble", JDouble(30.4)),
+        ("costdecimal", JDecimal(30.4)),
+        ("free", JBool(false))
+      )))
+
+    // Make sure that we index only metadata fields that end with "_"
+    sentenceDoc.getField("md-json").stringValue shouldBe "{\"title_\":\"Lucene tips and tricks\"}"
+  }
+  "addSentenceMetadata" should "return a document with no metadata field" in {
+
+    val sentenceDoc = new Document
+    addSentenceMetadata(sentenceDoc, JNothing)
+    sentenceDoc.getField("md-json") shouldBe null
   }
 
   "deserializeDocs" should "read the .json file and return a document with metadata"  in {


### PR DESCRIPTION
The PR adds the following capabilities:
* We now index metadata fields which end with underscore both at the parent document level AND the sentence document level.
  * In the parent document we add each of the metadata fields as a separate field which is indexed but not stored
  * In the sentence document we add only metadata fields which end with "_". All the metadata fields are added to a single sentence document field called "md-json" which is a stored field. The entire "md-json" dict will then be returned in rich-search queries and used by the client.
* We now have a mechanism to override the types of named fields in the `parentQueryParser`. We currently use this mechanism to set the type of "year" to "Integer". All other fields are strings by default.